### PR TITLE
Fixed glitch filter by un-initializing a variable

### DIFF
--- a/filters/glitch/src/GlitchFilter.ts
+++ b/filters/glitch/src/GlitchFilter.ts
@@ -108,7 +108,7 @@ class GlitchFilter extends Filter
     private _sizes: Float32Array = new Float32Array(1);
 
     /** direction is actually a setter for uniform.cosDir and uniform.sinDir. Initializing it prevents those values from being written! */
-    private _direction: number;
+    private _direction = -1;
 
     /**
      * @param {object} [options] - The more optional parameters of the filter.

--- a/filters/glitch/src/GlitchFilter.ts
+++ b/filters/glitch/src/GlitchFilter.ts
@@ -107,7 +107,9 @@ class GlitchFilter extends Filter
     private _offsets: Float32Array = new Float32Array(1);
     private _sizes: Float32Array = new Float32Array(1);
 
-    /** direction is actually a setter for uniform.cosDir and uniform.sinDir. Initializing it prevents those values from being written! */
+    /** direction is actually a setter for uniform.cosDir and uniform.sinDir.
+     * Must be initialized to something different than the default value.
+    */
     private _direction = -1;
 
     /**

--- a/filters/glitch/src/GlitchFilter.ts
+++ b/filters/glitch/src/GlitchFilter.ts
@@ -108,7 +108,7 @@ class GlitchFilter extends Filter
     private _sizes: Float32Array = new Float32Array(1);
 
     /** direction is actually a setter for uniform.cosDir and uniform.sinDir. Initializing it prevents those values from being written! */
-    private _direction = undefined;
+    private _direction: number;
 
     /**
      * @param {object} [options] - The more optional parameters of the filter.

--- a/filters/glitch/src/GlitchFilter.ts
+++ b/filters/glitch/src/GlitchFilter.ts
@@ -106,7 +106,9 @@ class GlitchFilter extends Filter
 
     private _offsets: Float32Array = new Float32Array(1);
     private _sizes: Float32Array = new Float32Array(1);
-    private _direction = 0;
+
+    /** direction is actually a setter for uniform.cosDir and uniform.sinDir. Initializing it prevents those values from being written! */
+    private _direction = undefined;
 
     /**
      * @param {object} [options] - The more optional parameters of the filter.


### PR DESCRIPTION
#299 

On line 109 GlitchFilter initialized the `this._direction` variable to zero.

This variable is the internal version of a setter `direction` that also writes the uniform `cosDir` and `sinDir` values **as long as the new `direction` value is different to the one in `_direction`**

Initializing `_direction` to zero makes the filter ignore when the direction is set to zero again thus never setting the `cosDir` and `sinDir` variable in the shader.

This PR un-initializes the `this._direction` as it will be initialized in the constructor via the setter `direction` anyway.