### PR TITLE
Update _resolution to be protected instead of private

### DIFF
--- a/filters/advanced-bloom/src/AdvancedBloomFilter.ts
+++ b/filters/advanced-bloom/src/AdvancedBloomFilter.ts
@@ -53,7 +53,7 @@ class AdvancedBloomFilter extends Filter
 
     private _extractFilter: ExtractBrightnessFilter;
     private _blurFilter: KawaseBlurFilter;
-    private _resolution: number = settings.FILTER_RESOLUTION;
+    protected _resolution: number = settings.FILTER_RESOLUTION;
 
     /**
      * @param {object|number} [options] - The optional parameters of advanced bloom filter.

--- a/filters/drop-shadow/src/DropShadowFilter.ts
+++ b/filters/drop-shadow/src/DropShadowFilter.ts
@@ -56,9 +56,9 @@ class DropShadowFilter extends Filter
     public angle = 45;
 
     private _distance = 5;
-    private _resolution: number = settings.FILTER_RESOLUTION;
     private _tintFilter: Filter;
     private _blurFilter: KawaseBlurFilter;
+    protected _resolution: number = settings.FILTER_RESOLUTION;
 
     /**
      * @param {object} [options] - Filter options


### PR DESCRIPTION
Follow-up to https://github.com/pixijs/pixijs/pull/7769.

When building with `typescript ^4.0.0` and `pixi ^6.1.3`, `AdvancedBloomFilter` and `DropShadowFilter` both complain about a protected property (`_resolution`) being overwritten by a private property.

This eliminates that error and doesn't seem to break anything for older versions of `typescript` or `pixi`.