### PR TITLE
dat.gui => lil-gui

### DIFF
--- a/tools/demo/index.css
+++ b/tools/demo/index.css
@@ -28,30 +28,18 @@ body {
     background:#000;
     padding:10px 0;
 }
-.dg.ac {
+.lil-gui.root {
     top:89px !important;
+    max-height: calc(100% - 89px);
 }
-.dg .title {
+.lil-gui .title { 
     color: #999;
-    user-select: none;
 }
-.dg.enabled .title {
+.lil-gui.enabled .title {
     color: #ea4080;
 }
 #logo img {
     display: block;
     margin:8px auto 0;
     width: 80%;
-}
-.dg .property-name .fa {
-    margin: 0 5px;
-}
-.dg .function .property-name {
-    width: 100%;
-}
-.dg .property-name {
-    width: 46%;
-}
-.dg .c {
-    width: 54%;
 }

--- a/tools/demo/index.html
+++ b/tools/demo/index.html
@@ -6,7 +6,7 @@
         <title>PixiJS Filters Demo</title>
         <meta name='viewport' content='width=device-width, initial-scale=1.0'>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" />
-        <script src="https://cdn.jsdelivr.net/npm/dat.gui@0.6.5/build/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.12.0"></script>
         <script src="https://pixijs.download/dev/pixi.min.js"></script>
         <link rel="stylesheet" href="index.css" />
     </head>

--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -11,9 +11,9 @@ import {
 
 const { EventEmitter } = utils;
 
-/* global dat,ga*/
+/* global lil,ga*/
 /**
- * Demo show a bunch of fish and a dat.gui controls
+ * Demo show a bunch of fish and a lil-gui controls
  * @class
  * @extends PIXI.Application
  */
@@ -21,7 +21,7 @@ export default class DemoApplication extends Application
 {
     constructor()
     {
-        const gui = new dat.GUI();
+        const gui = new lil.GUI();
 
         gui.useLocalStorage = false;
 
@@ -301,7 +301,7 @@ export default class DemoApplication extends Application
         }
 
         const app = this;
-        const folder = this.gui.addFolder(options.name);
+        const folder = this.gui.addFolder(options.name).close();
         const ClassRef = filters[id] || externalFilters[id];
 
         if (!ClassRef)


### PR DESCRIPTION
Hey all! I just released a library intended as a drop-in replacement for dat.gui called [lil-gui](https://lil-gui.georgealways.com/). The PixiJS Filters Demo is definitely one of the biggest dat.gui's out there, so it was a really valuable test case!

I've hosted the swap here:  https://lil-gui-pixi.georgealways.com/tools/demo/

We actually [just merged the same change](https://github.com/mrdoob/three.js/pull/22765#issue-1040513516) into three.js. Opening this PR in case you'd like to migrate officially, but no hurt feelings if not! ✌️