### PR TITLE
CRT filter didn't account for non power-of-2 texture bounds correctly…

### DIFF
--- a/filters/crt/src/crt.frag
+++ b/filters/crt/src/crt.frag
@@ -29,8 +29,8 @@ float rand(vec2 co) {
 void main(void)
 {
     vec2 pixelCoord = vTextureCoord.xy * filterArea.xy;
-    vec2 dir = vec2(vTextureCoord.xy - vec2(0.5, 0.5)) * filterArea.xy / dimensions;
-
+    vec2 dir = vec2(vTextureCoord.xy * filterArea.xy / dimensions - vec2(0.5, 0.5));
+    
     gl_FragColor = texture2D(uSampler, vTextureCoord);
     vec3 rgb = gl_FragColor.rgb;
 


### PR DESCRIPTION
…. This was most apparent when using vignetting - the oval was centered to the power-of-2 texture size rather than the actual content bounds. OldFilm filter got it right, so fixing Crt to work too.

The demo page works, I think because of "fullscreen" being a special case in the Filters code.  