### PR TITLE
Adds exports and mjs extension for Node.js

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -10,7 +10,14 @@
     "Chad Engler <chad@pantherdev.com>",
     "finscn <finscn@gmail.com>"
   ],
-  "module": "dist/pixi-filters.esm.js",
+  "module": "dist/pixi-filters.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/pixi-filters.esm.mjs",
+      "require": "./dist/pixi-filters.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "bundle": "dist/pixi-filters.js",
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",

--- a/filters/adjustment/package.json
+++ b/filters/adjustment/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-adjustment.js",
   "description": "PixiJS filter to adjust gamma, contrast, saturation, brightness or color channels",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-adjustment.esm.js",
+  "module": "dist/filter-adjustment.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-adjustment.esm.mjs",
+      "require": "./dist/filter-adjustment.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/advanced-bloom/package.json
+++ b/filters/advanced-bloom/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
-  "module": "dist/filter-advanced-bloom.esm.js",
+  "module": "dist/filter-advanced-bloom.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-advanced-bloom.esm.mjs",
+      "require": "./dist/filter-advanced-bloom.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/ascii/package.json
+++ b/filters/ascii/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-ascii.esm.js",
+  "module": "dist/filter-ascii.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-ascii.esm.mjs",
+      "require": "./dist/filter-ascii.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/bevel/package.json
+++ b/filters/bevel/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Evgeny Shestakov <ewanse@gmail.com>"
   ],
-  "module": "dist/filter-bevel.esm.js",
+  "module": "dist/filter-bevel.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-bevel.esm.mjs",
+      "require": "./dist/filter-bevel.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/bloom/package.json
+++ b/filters/bloom/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-bloom.esm.js",
+  "module": "dist/filter-bloom.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-bloom.esm.mjs",
+      "require": "./dist/filter-bloom.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/bulge-pinch/package.json
+++ b/filters/bulge-pinch/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-bulge-pinch.esm.js",
+  "module": "dist/filter-bulge-pinch.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-bulge-pinch.esm.mjs",
+      "require": "./dist/filter-bulge-pinch.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/color-map/package.json
+++ b/filters/color-map/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-color-map.js",
   "description": "PixiJS filter to apply a color adjust effect",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-color-map.esm.js",
+  "module": "dist/filter-color-map.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-color-map.esm.mjs",
+      "require": "./dist/filter-color-map.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/color-overlay/package.json
+++ b/filters/color-overlay/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Michael Deal <hello@mudcu.be>"
   ],
-  "module": "dist/filter-color-overlay.esm.js",
+  "module": "dist/filter-color-overlay.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-color-overlay.esm.mjs",
+      "require": "./dist/filter-color-overlay.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/color-replace/package.json
+++ b/filters/color-replace/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-color-replace.esm.js",
+  "module": "dist/filter-color-replace.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-color-replace.esm.mjs",
+      "require": "./dist/filter-color-replace.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/convolution/package.json
+++ b/filters/convolution/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-convolution.esm.js",
+  "module": "dist/filter-convolution.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-convolution.esm.mjs",
+      "require": "./dist/filter-convolution.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/cross-hatch/package.json
+++ b/filters/cross-hatch/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-cross-hatch.esm.js",
+  "module": "dist/filter-cross-hatch.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-cross-hatch.esm.mjs",
+      "require": "./dist/filter-cross-hatch.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/crt/package.json
+++ b/filters/crt/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-crt.js",
   "description": "PixiJS filter to apply an effect resembling old CRT monitors",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-crt.esm.js",
+  "module": "dist/filter-crt.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-crt.esm.mjs",
+      "require": "./dist/filter-crt.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/dot/package.json
+++ b/filters/dot/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-dot.esm.js",
+  "module": "dist/filter-dot.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-dot.esm.mjs",
+      "require": "./dist/filter-dot.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/drop-shadow/package.json
+++ b/filters/drop-shadow/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-drop-shadow.esm.js",
+  "module": "dist/filter-drop-shadow.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-drop-shadow.esm.mjs",
+      "require": "./dist/filter-drop-shadow.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/emboss/package.json
+++ b/filters/emboss/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-emboss.esm.js",
+  "module": "dist/filter-emboss.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-emboss.esm.mjs",
+      "require": "./dist/filter-emboss.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/glitch/package.json
+++ b/filters/glitch/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-glitch.js",
   "description": "PixiJS filter to apply a glitch effect",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-glitch.esm.js",
+  "module": "dist/filter-glitch.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-glitch.esm.mjs",
+      "require": "./dist/filter-glitch.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/glow/package.json
+++ b/filters/glow/package.json
@@ -9,7 +9,14 @@
     "Matt Karl <matt@mattkarl.com>",
     "Nils Kuhnhenn <lain@volafile.org>"
   ],
-  "module": "dist/filter-glow.esm.js",
+  "module": "dist/filter-glow.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-glow.esm.mjs",
+      "require": "./dist/filter-glow.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/godray/package.json
+++ b/filters/godray/package.json
@@ -9,7 +9,14 @@
     "Matt Karl <matt@mattkarl.com>",
     "Ivan Popelyshevl <ivan.popelyshev@gmail.com>"
   ],
-  "module": "dist/filter-godray.esm.js",
+  "module": "dist/filter-godray.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-godray.esm.mjs",
+      "require": "./dist/filter-godray.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/kawase-blur/package.json
+++ b/filters/kawase-blur/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-kawase-blur.js",
   "description": "PixiJS filter to apply an alternative, fast blur effect to Gaussian",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-kawase-blur.esm.js",
+  "module": "dist/filter-kawase-blur.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-kawase-blur.esm.mjs",
+      "require": "./dist/filter-kawase-blur.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/motion-blur/package.json
+++ b/filters/motion-blur/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-motion-blur.js",
   "description": "PixiJS filter to apply a directional blur effect",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-motion-blur.esm.js",
+  "module": "dist/filter-motion-blur.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-motion-blur.esm.mjs",
+      "require": "./dist/filter-motion-blur.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/multi-color-replace/package.json
+++ b/filters/multi-color-replace/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
-  "module": "dist/filter-multi-color-replace.esm.js",
+  "module": "dist/filter-multi-color-replace.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-multi-color-replace.esm.mjs",
+      "require": "./dist/filter-multi-color-replace.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/old-film/package.json
+++ b/filters/old-film/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-old-film.js",
   "description": "PixiJS filter to apply an old film effect with grain and scratches",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-old-film.esm.js",
+  "module": "dist/filter-old-film.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-old-film.esm.mjs",
+      "require": "./dist/filter-old-film.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/outline/package.json
+++ b/filters/outline/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-outline.esm.js",
+  "module": "dist/filter-outline.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-outline.esm.mjs",
+      "require": "./dist/filter-outline.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/pixelate/package.json
+++ b/filters/pixelate/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-pixelate.esm.js",
+  "module": "dist/filter-pixelate.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-pixelate.esm.mjs",
+      "require": "./dist/filter-pixelate.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/radial-blur/package.json
+++ b/filters/radial-blur/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-radial-blur.js",
   "description": "PixiJS filter to apply a radial blur effect",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-radial-blur.esm.js",
+  "module": "dist/filter-radial-blur.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-radial-blur.esm.mjs",
+      "require": "./dist/filter-radial-blur.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/reflection/package.json
+++ b/filters/reflection/package.json
@@ -5,7 +5,14 @@
   "bundle": "dist/filter-reflection.js",
   "description": "PixiJS filter to apply reflection and wave effect",
   "author": "finscn <finscn@gmail.com>",
-  "module": "dist/filter-reflection.esm.js",
+  "module": "dist/filter-reflection.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-reflection.esm.mjs",
+      "require": "./dist/filter-reflection.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/rgb-split/package.json
+++ b/filters/rgb-split/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-rgb-split.esm.js",
+  "module": "dist/filter-rgb-split.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-rgb-split.esm.mjs",
+      "require": "./dist/filter-rgb-split.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/shockwave/package.json
+++ b/filters/shockwave/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-shockwave.esm.js",
+  "module": "dist/filter-shockwave.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-shockwave.esm.mjs",
+      "require": "./dist/filter-shockwave.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/simple-lightmap/package.json
+++ b/filters/simple-lightmap/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-simple-lightmap.esm.js",
+  "module": "dist/filter-simple-lightmap.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-simple-lightmap.esm.mjs",
+      "require": "./dist/filter-simple-lightmap.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/tilt-shift/package.json
+++ b/filters/tilt-shift/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-tilt-shift.esm.js",
+  "module": "dist/filter-tilt-shift.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-tilt-shift.esm.mjs",
+      "require": "./dist/filter-tilt-shift.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "dist/filter-twist.esm.js",
+  "module": "dist/filter-twist.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-twist.esm.mjs",
+      "require": "./dist/filter-twist.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",

--- a/filters/zoom-blur/package.json
+++ b/filters/zoom-blur/package.json
@@ -8,7 +8,14 @@
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
-  "module": "dist/filter-zoom-blur.esm.js",
+  "module": "dist/filter-zoom-blur.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filter-zoom-blur.esm.mjs",
+      "require": "./dist/filter-zoom-blur.cjs.js",
+      "types": "./index.d.ts"
+    }
+  },
   "types": "index.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/filters/issues",


### PR DESCRIPTION
This adds support for Node's `exports` field in the package.json. Also, renames the extension on esm modules to be `.mjs` so that filters will work in a node-runtime environment.

Related to 
* https://github.com/pixijs/pixijs/pull/8371
* https://github.com/pixijs/pixijs/pull/8505