### PR TITLE
Update all filters links to their own docs

### DIFF
--- a/filters/adjustment/README.md
+++ b/filters/adjustment/README.md
@@ -20,4 +20,4 @@ container.filters = [new AdjustmentFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.AdjustmentFilter.html

--- a/filters/advanced-bloom/README.md
+++ b/filters/advanced-bloom/README.md
@@ -20,4 +20,4 @@ container.filters = [new AdvancedBloomFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.AdvancedBloomFilter.html

--- a/filters/ascii/README.md
+++ b/filters/ascii/README.md
@@ -20,4 +20,4 @@ container.filters = [new AsciiFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.AsciiFilter.html

--- a/filters/bevel/README.md
+++ b/filters/bevel/README.md
@@ -20,4 +20,4 @@ container.filters = [new BevelFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.BevelFilter.html

--- a/filters/bloom/README.md
+++ b/filters/bloom/README.md
@@ -20,4 +20,4 @@ container.filters = [new BloomFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.BloomFilter.html

--- a/filters/bulge-pinch/README.md
+++ b/filters/bulge-pinch/README.md
@@ -20,4 +20,4 @@ container.filters = [new BulgePinchFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.BulgePinchFilter.html

--- a/filters/color-map/README.md
+++ b/filters/color-map/README.md
@@ -23,4 +23,4 @@ container.filters = [new ColorMapFilter(colorMap)];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ColorMapFilter.html

--- a/filters/color-overlay/README.md
+++ b/filters/color-overlay/README.md
@@ -20,4 +20,4 @@ container.filters = [new ColorOverlayFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ColorOverlayFilter.html

--- a/filters/color-replace/README.md
+++ b/filters/color-replace/README.md
@@ -20,4 +20,4 @@ container.filters = [new ColorReplaceFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ColorReplaceFilter.html

--- a/filters/convolution/README.md
+++ b/filters/convolution/README.md
@@ -20,4 +20,4 @@ container.filters = [new ConvolutionFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ConvolutionFilter.html

--- a/filters/cross-hatch/README.md
+++ b/filters/cross-hatch/README.md
@@ -20,4 +20,4 @@ container.filters = [new CrossHatchFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.CrossHatchFilter.html

--- a/filters/crt/README.md
+++ b/filters/crt/README.md
@@ -20,4 +20,4 @@ container.filters = [new CRTFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.CRTFilter.html

--- a/filters/dot/README.md
+++ b/filters/dot/README.md
@@ -20,4 +20,4 @@ container.filters = [new DotFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.DotFilter.html

--- a/filters/drop-shadow/README.md
+++ b/filters/drop-shadow/README.md
@@ -20,4 +20,4 @@ container.filters = [new DropShadowFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.DropShadowFilter.html

--- a/filters/emboss/README.md
+++ b/filters/emboss/README.md
@@ -20,4 +20,4 @@ container.filters = [new EmbossFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.EmbossFilter.html

--- a/filters/glitch/README.md
+++ b/filters/glitch/README.md
@@ -20,4 +20,4 @@ container.filters = [new GlitchFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.GlitchFilter.html

--- a/filters/glow/README.md
+++ b/filters/glow/README.md
@@ -20,4 +20,4 @@ container.filters = [new GlowFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.GlowFilter.html

--- a/filters/godray/README.md
+++ b/filters/godray/README.md
@@ -20,4 +20,4 @@ container.filters = [new GodrayFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.GodrayFilter.html

--- a/filters/kawase-blur/README.md
+++ b/filters/kawase-blur/README.md
@@ -20,4 +20,4 @@ container.filters = [new KawaseBlurFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.KawaseBlurFilter.html

--- a/filters/motion-blur/README.md
+++ b/filters/motion-blur/README.md
@@ -20,4 +20,4 @@ container.filters = [new MotionBlurFilter([1,2], 9)];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.MotionBlurFilter.html

--- a/filters/multi-color-replace/README.md
+++ b/filters/multi-color-replace/README.md
@@ -26,4 +26,4 @@ container.filters = [
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.MultiColorReplaceFilter.html

--- a/filters/old-film/README.md
+++ b/filters/old-film/README.md
@@ -20,4 +20,4 @@ container.filters = [new OldFilmFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.OldFilmFilter.html

--- a/filters/outline/README.md
+++ b/filters/outline/README.md
@@ -20,4 +20,4 @@ container.filters = [new OutlineFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.OutlineFilter.html

--- a/filters/pixelate/README.md
+++ b/filters/pixelate/README.md
@@ -20,4 +20,4 @@ container.filters = [new PixelateFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.PixelateFilter.html

--- a/filters/radial-blur/README.md
+++ b/filters/radial-blur/README.md
@@ -20,4 +20,4 @@ container.filters = [new RadialBlurFilter(60, 9)];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.RadialBlurFilter.html

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -20,4 +20,4 @@ container.filters = [new ReflectionFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ReflectionFilter.html

--- a/filters/rgb-split/README.md
+++ b/filters/rgb-split/README.md
@@ -20,4 +20,4 @@ container.filters = [new RGBSplitFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.RGBSplitFilter.html

--- a/filters/shockwave/README.md
+++ b/filters/shockwave/README.md
@@ -20,4 +20,4 @@ container.filters = [new ShockwaveFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ShockwaveFilter.html

--- a/filters/simple-lightmap/README.md
+++ b/filters/simple-lightmap/README.md
@@ -20,4 +20,4 @@ container.filters = [new SimpleLightmapFilter(texture, [0, 0, 0, 0.5])];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.SimpleLightmapFilter.html

--- a/filters/tilt-shift/README.md
+++ b/filters/tilt-shift/README.md
@@ -20,4 +20,4 @@ container.filters = [new TiltShiftFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.TiltShiftFilter.html

--- a/filters/twist/README.md
+++ b/filters/twist/README.md
@@ -20,4 +20,4 @@ container.filters = [new TwistFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.TwistFilter.html

--- a/filters/zoom-blur/README.md
+++ b/filters/zoom-blur/README.md
@@ -20,4 +20,4 @@ container.filters = [new ZoomBlurFilter()];
 
 ## Documentation
 
-See https://pixijs.github.io/pixi-filters/docs
+See https://filters.pixijs.download/main/docs/PIXI.filters.ZoomBlurFilter.html


### PR DESCRIPTION
As the current link was pointing to the wrong home docs url, I replaced with the correct link with the specific page of the filter.