### PR TITLE
Chore: Update README typos, missing GrayscaleFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Click [here](https://pixijs.io/filters/tools/demo/) to interactively play with f
 
 ## Filters
 
-All filters work with PixiJS v5.
+All filters work with PixiJS v7.
 
 | Filter | Preview |
 |---|---|
@@ -29,7 +29,8 @@ All filters work with PixiJS v5.
 | **EmbossFilter**<br>_@pixi/filter-emboss_ | ![emboss](https://filters.pixijs.download/main/tools/screenshots/dist/emboss.png?v=2) |
 | **GlitchFilter**<br>_@pixi/filter-glitch_ | ![glitch](https://filters.pixijs.download/main/tools/screenshots/dist/glitch.png?v=1) |
 | **GlowFilter**<br>_@pixi/filter-glow_ | ![glow](https://filters.pixijs.download/main/tools/screenshots/dist/glow.png?v=2) |
-| **Godray**<br>_@pixi/filter-godray_ | ![godray](https://filters.pixijs.download/main/tools/screenshots/dist/godray.gif?v=2) |
+| **GodrayFilter**<br>_@pixi/filter-godray_ | ![godray](https://filters.pixijs.download/main/tools/screenshots/dist/godray.gif?v=2) |
+| **GrayscaleFilter**<br>_@pixi/filter-grayscale_ | ![grayscale](https://filters.pixijs.download/main/tools/screenshots/dist/grayscale.png?v=1) |
 | **KawaseBlurFilter**<br>_@pixi/filter-kawase-blur_ | ![kawase-blur](https://filters.pixijs.download/main/tools/screenshots/dist/kawase-blur.png?v=1) |
 | **MotionBlurFilter**<br>_@pixi/filter-motion-blur_ | ![motion-blur](https://filters.pixijs.download/main/tools/screenshots/dist/motion-blur.png?v=1) |
 | **MultiColorReplaceFilter**<br>_@pixi/filter-multi-color-replace_ | ![multi-color-replace](https://filters.pixijs.download/main/tools/screenshots/dist/multi-color-replace.png?v=1) |

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -2,7 +2,7 @@
 
 [![Node.js CI](https://github.com/pixijs/filters/workflows/Node.js%20CI/badge.svg)](https://github.com/pixi.js/pixi-filters/actions?query=workflow%3A%22Node.js+CI%22) [![npm version](https://badge.fury.io/js/pixi-filters.svg)](https://badge.fury.io/js/pixi-filters)
 
-PixiJS v5 optional display filters.
+PixiJS v7 optional display filters.
 
 Filters include:
 
@@ -24,6 +24,7 @@ Filters include:
 * **GlitchFilter** _@pixi/filter-glitch_
 * **GlowFilter** _@pixi/filter-glow_
 * **GodrayFilter** _@pixi/filter-godray_
+* **GrayscaleFilter** _@pixi/filter-grayscale_
 * **KawaseBlurFilter** _@pixi/filter-kawase-blur_
 * **MotionBlurFilter** _@pixi/filter-motion-blur_
 * **MultiColorFilter** _@pixi/filter-multi-color-replace_


### PR DESCRIPTION
### Chores

* Made sure it said "PixiJS v7", instead of v5
* Add GrayscaleFilter to READMEs