### PR TITLE
Allow using query string to enable filters in the demo application

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,67 +4,67 @@
 
 ## Demo
 
-Click [here](https://pixijs.io/filters/tools/demo/) to interactively play with filters to see how they work.
+[View the PixiJS Filters Demo](https://pixijs.io/filters/tools/demo/) to interactively play with filters to see how they work.
 
 ## Filters
 
 All filters work with PixiJS v7.
 
-| Filter | Preview |
-|---|---|
-| **AdjustmentFilter**<br>_@pixi/filter-adjustment_ | ![adjustment](https://filters.pixijs.download/main/tools/screenshots/dist/adjustment.png?v=2) |
-| **AdvancedBloomFilter**<br>_@pixi/filter-advanced-bloom_ | ![advanced-bloom](https://filters.pixijs.download/main/tools/screenshots/dist/advanced-bloom.png?v=2) |
-| **AsciiFilter**<br>_@pixi/filter-ascii_ | ![ascii](https://filters.pixijs.download/main/tools/screenshots/dist/ascii.png?v=2) |
-| **BevelFilter**<br>_@pixi/filter-bevel_ | ![bevel](https://filters.pixijs.download/main/tools/screenshots/dist/bevel.png?v=2) |
-| **BloomFilter**<br>_@pixi/filter-bloom_ | ![bloom](https://filters.pixijs.download/main/tools/screenshots/dist/bloom.png?v=2) |
-| **BulgePinchFilter**<br>_@pixi/filter-bulge-pinch_ | ![bulge-pinch](https://filters.pixijs.download/main/tools/screenshots/dist/bulge-pinch.gif?v=2) |
-| **ColorMapFilter**<br>_@pixi/filter-color-map_ | ![color-map](https://filters.pixijs.download/main/tools/screenshots/dist/color-map.png?v=2) |
-| **ColorOverlayFilter**<br>_@pixi/filter-color-overlay_ | ![color-overlay](https://filters.pixijs.download/main/tools/screenshots/dist/color-overlay.png?v=2) |
-| **ColorReplaceFilter**<br>_@pixi/filter-color-replace_ | ![color-replace](https://filters.pixijs.download/main/tools/screenshots/dist/color-replace.png?v=2) |
-| **ConvolutionFilter**<br>_@pixi/filter-convolution_ | ![convolution](https://filters.pixijs.download/main/tools/screenshots/dist/convolution.png?v=2) |
-| **CrossHatchFilter**<br>_@pixi/filter-cross-hatch_ | ![cross-hatch](https://filters.pixijs.download/main/tools/screenshots/dist/cross-hatch.png?v=2) |
-| **CRTFilter**<br>_@pixi/filter-crt_ | ![crt](https://filters.pixijs.download/main/tools/screenshots/dist/crt.png?v=2) |
-| **DotFilter**<br>_@pixi/filter-dot_ | ![dot](https://filters.pixijs.download/main/tools/screenshots/dist/dot.png?v=2) |
-| **DropShadowFilter**<br>_@pixi/filter-drop-shadow_| ![drop-shadow](https://filters.pixijs.download/main/tools/screenshots/dist/drop-shadow.png?v=2) |
-| **EmbossFilter**<br>_@pixi/filter-emboss_ | ![emboss](https://filters.pixijs.download/main/tools/screenshots/dist/emboss.png?v=2) |
-| **GlitchFilter**<br>_@pixi/filter-glitch_ | ![glitch](https://filters.pixijs.download/main/tools/screenshots/dist/glitch.png?v=1) |
-| **GlowFilter**<br>_@pixi/filter-glow_ | ![glow](https://filters.pixijs.download/main/tools/screenshots/dist/glow.png?v=2) |
-| **GodrayFilter**<br>_@pixi/filter-godray_ | ![godray](https://filters.pixijs.download/main/tools/screenshots/dist/godray.gif?v=2) |
-| **GrayscaleFilter**<br>_@pixi/filter-grayscale_ | ![grayscale](https://filters.pixijs.download/main/tools/screenshots/dist/grayscale.png?v=1) |
-| **KawaseBlurFilter**<br>_@pixi/filter-kawase-blur_ | ![kawase-blur](https://filters.pixijs.download/main/tools/screenshots/dist/kawase-blur.png?v=1) |
-| **MotionBlurFilter**<br>_@pixi/filter-motion-blur_ | ![motion-blur](https://filters.pixijs.download/main/tools/screenshots/dist/motion-blur.png?v=1) |
-| **MultiColorReplaceFilter**<br>_@pixi/filter-multi-color-replace_ | ![multi-color-replace](https://filters.pixijs.download/main/tools/screenshots/dist/multi-color-replace.png?v=1) |
-| **OldFilmFilter**<br>_@pixi/filter-old-film_ | ![old-film](https://filters.pixijs.download/main/tools/screenshots/dist/old-film.gif?v=2) |
-| **OutlineFilter**<br>_@pixi/filter-outline_ | ![outline](https://filters.pixijs.download/main/tools/screenshots/dist/outline.png?v=2) |
-| **PixelateFilter**<br>_@pixi/filter-pixelate_ | ![pixelate](https://filters.pixijs.download/main/tools/screenshots/dist/pixelate.png?v=2) |
-| **RadialBlurFilter**<br>_@pixi/filter-radial-blur_ | ![radial-blur](https://filters.pixijs.download/main/tools/screenshots/dist/radial-blur.png?v=2) |
-| **ReflectionFilter**<br>_@pixi/filter-reflection_ | ![reflection](https://filters.pixijs.download/main/tools/screenshots/dist/reflection.png?v=2) |
-| **RGBSplitFilter**<br>_@pixi/filter-rgb-split_ | ![rgb split](https://filters.pixijs.download/main/tools/screenshots/dist/rgb.png?v=2) |
-| **ShockwaveFilter**<br>_@pixi/filter-shockwave_ | ![shockwave](https://filters.pixijs.download/main/tools/screenshots/dist/shockwave.gif?v=3) |
-| **SimpleLightmapFilter**<br>_@pixi/filter-simple-lightmap_ | ![simple-lightmap](https://filters.pixijs.download/main/tools/screenshots/dist/simple-lightmap.png?v=2) |
-| **TiltShiftFilter**<br>_@pixi/filter-tilt-shift_ | ![tilt-shift](https://filters.pixijs.download/main/tools/screenshots/dist/tilt-shift.png?v=2) |
-| **TwistFilter**<br>_@pixi/filter-twist_ | ![twist](https://filters.pixijs.download/main/tools/screenshots/dist/twist.png?v=2) |
-| **ZoomBlurFilter**<br>_@pixi/filter-zoom-blur_ | ![zoom-blur](https://filters.pixijs.download/main/tools/screenshots/dist/zoom-blur.png?v=4) |
+| Filter                                                                                                   | Preview                                                                                                         |
+|----------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| **AdjustmentFilter**<br>_@pixi/filter-adjustment_<br>[View demo][Adjustment_demo]                        | ![adjustment](https://filters.pixijs.download/main/tools/screenshots/dist/adjustment.png?v=2)                   |
+| **AdvancedBloomFilter**<br>_@pixi/filter-advanced-bloom_<br>[View demo][AdvancedBloom_demo]              | ![advanced-bloom](https://filters.pixijs.download/main/tools/screenshots/dist/advanced-bloom.png?v=2)           |
+| **AsciiFilter**<br>_@pixi/filter-ascii_<br>[View demo][Ascii_demo]                                       | ![ascii](https://filters.pixijs.download/main/tools/screenshots/dist/ascii.png?v=2)                             |
+| **BevelFilter**<br>_@pixi/filter-bevel_<br>[View demo][Bevel_demo]                                       | ![bevel](https://filters.pixijs.download/main/tools/screenshots/dist/bevel.png?v=2)                             |
+| **BloomFilter**<br>_@pixi/filter-bloom_<br>[View demo][Bloom_demo]                                       | ![bloom](https://filters.pixijs.download/main/tools/screenshots/dist/bloom.png?v=2)                             |
+| **BulgePinchFilter**<br>_@pixi/filter-bulge-pinch_<br>[View demo][BulgePinch_demo]                       | ![bulge-pinch](https://filters.pixijs.download/main/tools/screenshots/dist/bulge-pinch.gif?v=2)                 |
+| **ColorMapFilter**<br>_@pixi/filter-color-map_<br>[View demo][ColorMap_demo]                             | ![color-map](https://filters.pixijs.download/main/tools/screenshots/dist/color-map.png?v=2)                     |
+| **ColorOverlayFilter**<br>_@pixi/filter-color-overlay_<br>[View demo][ColorOverlay_demo]                 | ![color-overlay](https://filters.pixijs.download/main/tools/screenshots/dist/color-overlay.png?v=2)             |
+| **ColorReplaceFilter**<br>_@pixi/filter-color-replace_<br>[View demo][ColorReplace_demo]                 | ![color-replace](https://filters.pixijs.download/main/tools/screenshots/dist/color-replace.png?v=2)             |
+| **ConvolutionFilter**<br>_@pixi/filter-convolution_<br>[View demo][Convolution_demo]                     | ![convolution](https://filters.pixijs.download/main/tools/screenshots/dist/convolution.png?v=2)                 |
+| **CrossHatchFilter**<br>_@pixi/filter-cross-hatch_<br>[View demo][CrossHatch_demo]                       | ![cross-hatch](https://filters.pixijs.download/main/tools/screenshots/dist/cross-hatch.png?v=2)                 |
+| **CRTFilter**<br>_@pixi/filter-crt_<br>[View demo][CRT_demo]                                             | ![crt](https://filters.pixijs.download/main/tools/screenshots/dist/crt.png?v=2)                                 |
+| **DotFilter**<br>_@pixi/filter-dot_<br>[View demo][Dot_demo]                                             | ![dot](https://filters.pixijs.download/main/tools/screenshots/dist/dot.png?v=2)                                 |
+| **DropShadowFilter**<br>_@pixi/filter-drop-shadow_<br>[View demo][DropShadow_demo]                       | ![drop-shadow](https://filters.pixijs.download/main/tools/screenshots/dist/drop-shadow.png?v=2)                 |
+| **EmbossFilter**<br>_@pixi/filter-emboss_<br>[View demo][Emboss_demo]                                    | ![emboss](https://filters.pixijs.download/main/tools/screenshots/dist/emboss.png?v=2)                           |
+| **GlitchFilter**<br>_@pixi/filter-glitch_<br>[View demo][Glitch_demo]                                    | ![glitch](https://filters.pixijs.download/main/tools/screenshots/dist/glitch.png?v=1)                           |
+| **GlowFilter**<br>_@pixi/filter-glow_<br>[View demo][Glow_demo]                                          | ![glow](https://filters.pixijs.download/main/tools/screenshots/dist/glow.png?v=2)                               |
+| **GodrayFilter**<br>_@pixi/filter-godray_<br>[View demo][Godray_demo]                                    | ![godray](https://filters.pixijs.download/main/tools/screenshots/dist/godray.gif?v=2)                           |
+| **GrayscaleFilter**<br>_@pixi/filter-grayscale_<br>[View demo][Grayscale_demo]                           | ![grayscale](https://filters.pixijs.download/main/tools/screenshots/dist/grayscale.png?v=1)                     |
+| **KawaseBlurFilter**<br>_@pixi/filter-kawase-blur_<br>[View demo][KawaseBlur_demo]                       | ![kawase-blur](https://filters.pixijs.download/main/tools/screenshots/dist/kawase-blur.png?v=1)                 |
+| **MotionBlurFilter**<br>_@pixi/filter-motion-blur_<br>[View demo][MotionBlur_demo]                       | ![motion-blur](https://filters.pixijs.download/main/tools/screenshots/dist/motion-blur.png?v=1)                 |
+| **MultiColorReplaceFilter**<br>_@pixi/filter-multi-color-replace_<br>[View demo][MultiColorReplace_demo] | ![multi-color-replace](https://filters.pixijs.download/main/tools/screenshots/dist/multi-color-replace.png?v=1) |
+| **OldFilmFilter**<br>_@pixi/filter-old-film_<br>[View demo][OldFilm_demo]                                | ![old-film](https://filters.pixijs.download/main/tools/screenshots/dist/old-film.gif?v=2)                       |
+| **OutlineFilter**<br>_@pixi/filter-outline_<br>[View demo][Outline_demo]                                 | ![outline](https://filters.pixijs.download/main/tools/screenshots/dist/outline.png?v=2)                         |
+| **PixelateFilter**<br>_@pixi/filter-pixelate_<br>[View demo][Pixelate_demo]                              | ![pixelate](https://filters.pixijs.download/main/tools/screenshots/dist/pixelate.png?v=2)                       |
+| **RadialBlurFilter**<br>_@pixi/filter-radial-blur_<br>[View demo][RadialBlur_demo]                       | ![radial-blur](https://filters.pixijs.download/main/tools/screenshots/dist/radial-blur.png?v=2)                 |
+| **ReflectionFilter**<br>_@pixi/filter-reflection_<br>[View demo][Reflection_demo]                        | ![reflection](https://filters.pixijs.download/main/tools/screenshots/dist/reflection.png?v=2)                   |
+| **RGBSplitFilter**<br>_@pixi/filter-rgb-split_<br>[View demo][RGBSplit_demo]                             | ![rgb split](https://filters.pixijs.download/main/tools/screenshots/dist/rgb.png?v=2)                           |
+| **ShockwaveFilter**<br>_@pixi/filter-shockwave_<br>[View demo][Shockwave_demo]                           | ![shockwave](https://filters.pixijs.download/main/tools/screenshots/dist/shockwave.gif?v=3)                     |
+| **SimpleLightmapFilter**<br>_@pixi/filter-simple-lightmap_<br>[View demo][SimpleLightmap_demo]           | ![simple-lightmap](https://filters.pixijs.download/main/tools/screenshots/dist/simple-lightmap.png?v=2)         |
+| **TiltShiftFilter**<br>_@pixi/filter-tilt-shift_<br>[View demo][TiltShift_demo]                          | ![tilt-shift](https://filters.pixijs.download/main/tools/screenshots/dist/tilt-shift.png?v=2)                   |
+| **TwistFilter**<br>_@pixi/filter-twist_<br>[View demo][Twist_demo]                                       | ![twist](https://filters.pixijs.download/main/tools/screenshots/dist/twist.png?v=2)                             |
+| **ZoomBlurFilter**<br>_@pixi/filter-zoom-blur_<br>[View demo][ZoomBlur_demo]                             | ![zoom-blur](https://filters.pixijs.download/main/tools/screenshots/dist/zoom-blur.png?v=4)                     |
 
 ## Built-In Filters
 
 PixiJS has a handful of core filters that are built-in to the PixiJS library.
 
-| Filter | Preview |
-|---|---|
-| **AlphaFilter** | ![alpha](https://filters.pixijs.download/main/tools/screenshots/dist/alpha.png?v=2) |
-| **BlurFilter** | ![blur](https://filters.pixijs.download/main/tools/screenshots/dist/blur.png?v=2) |
-| **ColorMatrixFilter** (contrast) | ![color-matrix-contrast](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-contrast.png?v=2) |
-| **ColorMatrixFilter** (desaturate) | ![color-matrix-desaturate](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-desaturate.png?v=2) |
-| **ColorMatrixFilter** (kodachrome) | ![color-matrix-kodachrome](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-kodachrome.png?v=2) |
-| **ColorMatrixFilter** (lsd) | ![color-matrix-lsd](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-lsd.png?v=2) |
-| **ColorMatrixFilter** (negative) | ![color-matrix-negative](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-negative.png?v=2) |
-| **ColorMatrixFilter** (polaroid) | ![color-matrix-polaroid](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-polaroid.png?v=2) |
-| **ColorMatrixFilter** (predator) | ![color-matrix-predator](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-predator.png?v=2) |
-| **ColorMatrixFilter** (saturate) | ![color-matrix-saturate](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-saturate.png?v=2) |
-| **ColorMatrixFilter** (sepia) | ![color-matrix-sepia](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-sepia.png?v=2) |
-| **DisplacementFilter** | ![displacement](https://filters.pixijs.download/main/tools/screenshots/dist/displacement.png?v=2) |
-| **NoiseFilter** | ![noise](https://filters.pixijs.download/main/tools/screenshots/dist/noise.png?v=2) |
+| Filter                                                          | Preview                                                                                                                 |
+|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| **AlphaFilter**<br>[View demo][Alpha_demo]                      | ![alpha](https://filters.pixijs.download/main/tools/screenshots/dist/alpha.png?v=2)                                     |
+| **BlurFilter**<br>[View demo][Blur_demo]                        | ![blur](https://filters.pixijs.download/main/tools/screenshots/dist/blur.png?v=2)                                       |
+| **ColorMatrixFilter** (contrast)[View demo][ColorMatrix_demo]   | ![color-matrix-contrast](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-contrast.png?v=2)     |
+| **ColorMatrixFilter** (desaturate)[View demo][ColorMatrix_demo] | ![color-matrix-desaturate](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-desaturate.png?v=2) |
+| **ColorMatrixFilter** (kodachrome)[View demo][ColorMatrix_demo] | ![color-matrix-kodachrome](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-kodachrome.png?v=2) |
+| **ColorMatrixFilter** (lsd)[View demo][ColorMatrix_demo]        | ![color-matrix-lsd](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-lsd.png?v=2)               |
+| **ColorMatrixFilter** (negative)[View demo][ColorMatrix_demo]   | ![color-matrix-negative](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-negative.png?v=2)     |
+| **ColorMatrixFilter** (polaroid)[View demo][ColorMatrix_demo]   | ![color-matrix-polaroid](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-polaroid.png?v=2)     |
+| **ColorMatrixFilter** (predator)[View demo][ColorMatrix_demo]   | ![color-matrix-predator](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-predator.png?v=2)     |
+| **ColorMatrixFilter** (saturate)[View demo][ColorMatrix_demo]   | ![color-matrix-saturate](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-saturate.png?v=2)     |
+| **ColorMatrixFilter** (sepia)[View demo][ColorMatrix_demo]      | ![color-matrix-sepia](https://filters.pixijs.download/main/tools/screenshots/dist/color-matrix-sepia.png?v=2)           |
+| **DisplacementFilter**<br>[View demo][Displacement_demo]        | ![displacement](https://filters.pixijs.download/main/tools/screenshots/dist/displacement.png?v=2)                       |
+| **NoiseFilter**<br>[View demo][Noise_demo]                      | ![noise](https://filters.pixijs.download/main/tools/screenshots/dist/noise.png?v=2)                                     |
 
 ## Installation
 
@@ -105,3 +105,44 @@ npm run watch
 ## Documentation
 
 API documention can be found [here](http://pixijs.io/filters/docs/).
+
+<!-- references -->
+[Adjustment_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=AdjustmentFilter
+[AdvancedBloom_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=AdvancedBloomFilter
+[Ascii_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=AsciiFilter
+[Bevel_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=BevelFilter
+[Bloom_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=BloomFilter
+[BulgePinch_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=BulgePinchFilter
+[ColorMap_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ColorMapFilter
+[ColorOverlay_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ColorOverlayFilter
+[ColorReplace_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ColorReplaceFilter
+[Convolution_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ConvolutionFilter
+[CrossHatch_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=CrossHatchFilter
+[CRT_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=CRTFilter
+[Dot_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=DotFilter
+[DropShadow_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=DropShadowFilter
+[Emboss_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=EmbossFilter
+[Glitch_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=GlitchFilter
+[Glow_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=GlowFilter
+[Godray_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=GodrayFilter
+[Grayscale_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=GrayscaleFilter
+[KawaseBlur_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=KawaseBlurFilter
+[MotionBlur_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=MotionBlurFilter
+[MultiColorReplace_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=MultiColorReplaceFilter
+[OldFilm_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=OldFilmFilter
+[Outline_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=OutlineFilter
+[Pixelate_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=PixelateFilter
+[RadialBlur_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=RadialBlurFilter
+[Reflection_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ReflectionFilter
+[RGBSplit_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=RGBSplitFilter
+[Shockwave_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ShockwaveFilter
+[SimpleLightmap_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=SimpleLightmapFilter
+[TiltShift_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=TiltShiftFilter
+[Twist_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=TwistFilter
+[ZoomBlur_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ZoomBlurFilter
+
+[Alpha_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=AlphaFilter
+[Blur_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=BlurFilter
+[ColorMatrix_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=ColorMatrixFilter
+[Displacement_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=DisplacementFilter
+[Noise_demo]: https://filters.pixijs.download/main/demo/index.html?enabled=NoiseFilter

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -6,43 +6,45 @@ PixiJS v7 optional display filters.
 
 Filters include:
 
-* **AdjustmentFilter** _@pixi/filter-adjustment_
-* **AdvancedBloomFilter** _@pixi/filter-advanced-bloom_
-* **AsciiFilter** _@pixi/filter-ascii_
-* **BevelFilter** _@pixi/filter-bevel_
-* **BloomFilter** _@pixi/filter-bloom_
-* **BulgePinchFilter** _@pixi/filter-bulge-pinch_
-* **ColorMapFilter** _@pixi/filter-color-map_
-* **ColorOverlayFilter** _@pixi/filter-color-overlay_
-* **ColorReplaceFilter** _@pixi/filter-color-replace_
-* **ConvolutionFilter** _@pixi/filter-convolution_
-* **CrossHatchFilter** _@pixi/filter-cross-hatch_
-* **CRTFilter** _@pixi/filter-crt_
-* **DotFilter** _@pixi/filter-dot_
-* **DropShadowFilter** _@pixi/filter-drop-shadow_
-* **EmbossFilter** _@pixi/filter-emboss_
-* **GlitchFilter** _@pixi/filter-glitch_
-* **GlowFilter** _@pixi/filter-glow_
-* **GodrayFilter** _@pixi/filter-godray_
-* **GrayscaleFilter** _@pixi/filter-grayscale_
-* **KawaseBlurFilter** _@pixi/filter-kawase-blur_
-* **MotionBlurFilter** _@pixi/filter-motion-blur_
-* **MultiColorFilter** _@pixi/filter-multi-color-replace_
-* **OldFilmFilter** _@pixi/filter-old-film_
-* **OutlineFilter** _@pixi/filter-outline_
-* **PixelateFilter** _@pixi/filter-pixelate_
-* **RadialBlurFilter** _@pixi/filter-radial-blur_
-* **ReflectionFilter** _@pixi/filter-reflection_
-* **RGBSplitFilter** _@pixi/filter-rgb_
-* **ShockwaveFilter** _@pixi/filter-shockwave_
-* **SimpleLightmapFilter** _@pixi/filter-simple-lightmap_
-* **TiltShiftFilter** _@pixi/filter-tilt-shift_
-* **TwistFilter** _@pixi/filter-twist_
-* **ZoomBlurFilter** _@pixi/filter-zoom-blur_
+| Name                     | Package                                                                                            | Demo                                                                                           |
+|--------------------------|----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| **AdjustmentFilter**     | [@pixi/filter-adjustment](https://www.npmjs.com/package/@pixi/filter-adjustment)                   | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AdjustmentFilter)     |
+| **AdvancedBloomFilter**  | [@pixi/filter-advanced-bloom](https://www.npmjs.com/package/@pixi/filter-advanced-bloom)           | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AdvancedBloomFilter)  |
+| **AsciiFilter**          | [@pixi/filter-ascii](https://www.npmjs.com/package/@pixi/filter-ascii)                             | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AsciiFilter)          |
+| **BevelFilter**          | [@pixi/filter-bevel](https://www.npmjs.com/package/@pixi/filter-bevel)                             | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=BevelFilter)          |
+| **BloomFilter**          | [@pixi/filter-bloom](https://www.npmjs.com/package/@pixi/filter-bloom)                             | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=BloomFilter)          |
+| **BulgePinchFilter**     | [@pixi/filter-bulge-pinch](https://www.npmjs.com/package/@pixi/filter-bulge-pinch)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=BulgePinchFilter)     |
+| **ColorMapFilter**       | [@pixi/filter-color-map](https://www.npmjs.com/package/@pixi/filter-color-map)                     | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ColorMapFilter)       |
+| **ColorOverlayFilter**   | [@pixi/filter-color-overlay](https://www.npmjs.com/package/@pixi/filter-color-overlay)             | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ColorOverlayFilter)   |
+| **ColorReplaceFilter**   | [@pixi/filter-color-replace](https://www.npmjs.com/package/@pixi/filter-color-replace)             | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ColorReplaceFilter)   |
+| **ConvolutionFilter**    | [@pixi/filter-convolution](https://www.npmjs.com/package/@pixi/filter-convolution)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ConvolutionFilter)    |
+| **CrossHatchFilter**     | [@pixi/filter-cross-hatch](https://www.npmjs.com/package/@pixi/filter-cross-hatch)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=CrossHatchFilter)     |
+| **CRTFilter**            | [@pixi/filter-crt](https://www.npmjs.com/package/@pixi/filter-crt)                                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=CRTFilter)            |
+| **DotFilter**            | [@pixi/filter-dot](https://www.npmjs.com/package/@pixi/filter-dot)                                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=DotFilter)            |
+| **DropShadowFilter**     | [@pixi/filter-drop-shadow](https://www.npmjs.com/package/@pixi/filter-drop-shadow)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=DropShadowFilter)     |
+| **EmbossFilter**         | [@pixi/filter-emboss](https://www.npmjs.com/package/@pixi/filter-emboss)                           | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=EmbossFilter)         |
+| **GlitchFilter**         | [@pixi/filter-glitch](https://www.npmjs.com/package/@pixi/filter-glitch)                           | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GlitchFilter)         |
+| **GlowFilter**           | [@pixi/filter-glow](https://www.npmjs.com/package/@pixi/filter-glow)                               | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GlowFilter)           |
+| **GodrayFilter**         | [@pixi/filter-godray](https://www.npmjs.com/package/@pixi/filter-godray)                           | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GodrayFilter)         |
+| **GrayscaleFilter**      | [@pixi/filter-grayscale](https://www.npmjs.com/package/@pixi/filter-grayscale)                     | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GrayscaleFilter)      |
+| **KawaseBlurFilter**     | [@pixi/filter-kawase-blur](https://www.npmjs.com/package/@pixi/filter-kawase-blur)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=KawaseBlurFilter)     |
+| **MotionBlurFilter**     | [@pixi/filter-motion-blur](https://www.npmjs.com/package/@pixi/filter-motion-blur)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=MotionBlurFilter)     |
+| **MultiColorFilter**     | [@pixi/filter-multi-color-replace](https://www.npmjs.com/package/@pixi/filter-multi-color-replace) | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=MultiColorFilter)     |
+| **OldFilmFilter**        | [@pixi/filter-old-film](https://www.npmjs.com/package/@pixi/filter-old-film)                       | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=OldFilmFilter)        |
+| **OutlineFilter**        | [@pixi/filter-outline](https://www.npmjs.com/package/@pixi/filter-outline)                         | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=OutlineFilter)        |
+| **PixelateFilter**       | [@pixi/filter-pixelate](https://www.npmjs.com/package/@pixi/filter-pixelate)                       | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=PixelateFilter)       |
+| **RadialBlurFilter**     | [@pixi/filter-radial-blur](https://www.npmjs.com/package/@pixi/filter-radial-blur)                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=RadialBlurFilter)     |
+| **ReflectionFilter**     | [@pixi/filter-reflection](https://www.npmjs.com/package/@pixi/filter-reflection)                   | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ReflectionFilter)     |
+| **RGBSplitFilter**       | [@pixi/filter-rgb](https://www.npmjs.com/package/@pixi/filter-rgb)                                 | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=RGBSplitFilter)       |
+| **ShockwaveFilter**      | [@pixi/filter-shockwave](https://www.npmjs.com/package/@pixi/filter-shockwave)                     | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ShockwaveFilter)      |
+| **SimpleLightmapFilter** | [@pixi/filter-simple-lightmap](https://www.npmjs.com/package/@pixi/filter-simple-lightmap)         | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=SimpleLightmapFilter) |
+| **TiltShiftFilter**      | [@pixi/filter-tilt-shift](https://www.npmjs.com/package/@pixi/filter-tilt-shift)                   | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=TiltShiftFilter)      |
+| **TwistFilter**          | [@pixi/filter-twist](https://www.npmjs.com/package/@pixi/filter-twist)                             | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=TwistFilter)          |
+| **ZoomBlurFilter**       | [@pixi/filter-zoom-blur](https://www.npmjs.com/package/@pixi/filter-zoom-blur)                     | [View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ZoomBlurFilter)       |
 
 ## Examples
 
-Click [here](http://pixijs.io/filters/tools/demo/) for filter demos.
+[View the PixiJS Filters Demo](https://pixijs.io/filters/tools/demo/) to interactively play with filters to see how they work.
 
 ## Installation
 

--- a/filters/adjustment/README.md
+++ b/filters/adjustment/README.md
@@ -1,6 +1,8 @@
 # AdjustmentFilter
 
-PixiJS filter to adjust gamma, contrast, saturation, brightness or color channels.
+> PixiJS filter to adjust gamma, contrast, saturation, brightness or color channels.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AdjustmentFilter)
 
 ## Installation
 

--- a/filters/advanced-bloom/README.md
+++ b/filters/advanced-bloom/README.md
@@ -1,6 +1,8 @@
 # AdvancedBloomFilter
 
-PixiJS filter to render Bloom Filter (with highlight) effect.
+> PixiJS filter to render Bloom Filter (with highlight) effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AdvancedBloomFilter)
 
 ## Installation
 

--- a/filters/ascii/README.md
+++ b/filters/ascii/README.md
@@ -1,6 +1,8 @@
 # AsciiFilter
 
-PixiJS filter to render DisplayObject as ASCII text.
+> PixiJS filter to render DisplayObject as ASCII text.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AsciiFilter)
 
 ## Installation
 

--- a/filters/bevel/README.md
+++ b/filters/bevel/README.md
@@ -1,6 +1,8 @@
 # BevelFilter
 
-PixiJS filter to apply a bevel effect.
+> PixiJS filter to apply a bevel effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=BevelFilter)
 
 ## Installation
 

--- a/filters/bloom/README.md
+++ b/filters/bloom/README.md
@@ -1,6 +1,8 @@
 # BloomFilter
 
-PixiJS filter to apply a simple bloom effect.
+> PixiJS filter to apply a simple bloom effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=BloomFilter)
 
 ## Installation
 

--- a/filters/bulge-pinch/README.md
+++ b/filters/bulge-pinch/README.md
@@ -1,6 +1,8 @@
 # BulgePinchFilter
 
-PixiJS filter to apply a bulge or a pinch effect.
+> PixiJS filter to apply a bulge or a pinch effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=BulgePinchFilter)
 
 ## Installation
 

--- a/filters/color-map/README.md
+++ b/filters/color-map/README.md
@@ -1,6 +1,8 @@
 # ColorMapFilter
 
-PixiJS filter to apply a color-map effect.
+> PixiJS filter to apply a color-map effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ColorMapFilter)
 
 ## Installation
 

--- a/filters/color-overlay/README.md
+++ b/filters/color-overlay/README.md
@@ -1,6 +1,8 @@
 # ColorOverlayFilter
 
-PixiJS filter to overlay all colors with single color.
+> PixiJS filter to overlay all colors with single color.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ColorOverlayFilter)
 
 ## Installation
 

--- a/filters/color-replace/README.md
+++ b/filters/color-replace/README.md
@@ -1,6 +1,8 @@
 # ColorReplaceFilter
 
-PixiJS filter to replace a single color.
+> PixiJS filter to replace a single color.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ColorReplaceFilter)
 
 ## Installation
 

--- a/filters/convolution/README.md
+++ b/filters/convolution/README.md
@@ -1,6 +1,8 @@
 # ConvolutionFilter
 
-PixiJS filter to apply a convolution effect.
+> PixiJS filter to apply a convolution effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ConvolutionFilter)
 
 ## Installation
 

--- a/filters/cross-hatch/README.md
+++ b/filters/cross-hatch/README.md
@@ -1,6 +1,8 @@
 # CrossHatchFilter
 
-PixiJS filter to apply a cross-hatch black and white effect.
+> PixiJS filter to apply a cross-hatch black and white effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=CrossHatchFilter)
 
 ## Installation
 

--- a/filters/crt/README.md
+++ b/filters/crt/README.md
@@ -1,6 +1,8 @@
 # CRTFilter
 
-PixiJS filter to apply an effect resembling old CRT monitors.
+> PixiJS filter to apply an effect resembling old CRT monitors.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=CRTFilter)
 
 ## Installation
 

--- a/filters/dot/README.md
+++ b/filters/dot/README.md
@@ -1,6 +1,8 @@
 # DotFilter
 
-PixiJS filter to apply a black and white dot effect.
+> PixiJS filter to apply a black and white dot effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=DotFilter)
 
 ## Installation
 

--- a/filters/drop-shadow/README.md
+++ b/filters/drop-shadow/README.md
@@ -1,6 +1,8 @@
 # DropShadowFilter
 
-PixiJS filter to apply a drop shadow effect.
+> PixiJS filter to apply a drop shadow effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=DropShadowFilter)
 
 ## Installation
 

--- a/filters/emboss/README.md
+++ b/filters/emboss/README.md
@@ -1,6 +1,8 @@
 # EmbossFilter
 
-PixiJS filter to apply an emboss effect.
+> PixiJS filter to apply an emboss effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=EmbossFilter)
 
 ## Installation
 

--- a/filters/glitch/README.md
+++ b/filters/glitch/README.md
@@ -1,6 +1,8 @@
 # GlitchFilter
 
-PixiJS filter to apply a glitch effect.
+> PixiJS filter to apply a glitch effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GlitchFilter)
 
 ## Installation
 

--- a/filters/glow/README.md
+++ b/filters/glow/README.md
@@ -1,6 +1,8 @@
 # GlowFilter
 
-PixiJS filter to apply a glow effect.
+> PixiJS filter to apply a glow effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GlowFilter)
 
 ## Installation
 

--- a/filters/godray/README.md
+++ b/filters/godray/README.md
@@ -1,6 +1,8 @@
 # GodrayFilter
 
-PixiJS filter to apply and animate atmospheric light rays.
+> PixiJS filter to apply and animate atmospheric light rays.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GodrayFilter)
 
 ## Installation
 

--- a/filters/grayscale/README.md
+++ b/filters/grayscale/README.md
@@ -1,6 +1,8 @@
 # GrayscaleFilter
 
-PixiJS filter to apply a grayscale effect.
+> PixiJS filter to apply a grayscale effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=GrayscaleFilter)
 
 ## Installation
 

--- a/filters/kawase-blur/README.md
+++ b/filters/kawase-blur/README.md
@@ -1,6 +1,8 @@
 # KawaseBlurFilter
 
-PixiJS filter to apply an alternative, fast blur effect to Gaussian.
+> PixiJS filter to apply an alternative, fast blur effect to Gaussian.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=KawaseBlurFilter)
 
 ## Installation
 

--- a/filters/motion-blur/README.md
+++ b/filters/motion-blur/README.md
@@ -1,6 +1,8 @@
 # MotionBlurFilter
 
-PixiJS filter to apply a directional blur effect.
+> PixiJS filter to apply a directional blur effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=MotionBlurFilter)
 
 ## Installation
 

--- a/filters/multi-color-replace/README.md
+++ b/filters/multi-color-replace/README.md
@@ -1,6 +1,8 @@
 # MultiColorReplaceFilter
 
-PixiJS filter to dynamically replace multiple colors.
+> PixiJS filter to dynamically replace multiple colors.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=MultiColorReplaceFilter)
 
 ## Installation
 

--- a/filters/old-film/README.md
+++ b/filters/old-film/README.md
@@ -1,6 +1,8 @@
 # OldFilmFilter
 
-PixiJS filter to apply an old film effect with grain and scratches.
+> PixiJS filter to apply an old film effect with grain and scratches.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=OldFilmFilter)
 
 ## Installation
 

--- a/filters/outline/README.md
+++ b/filters/outline/README.md
@@ -1,6 +1,8 @@
 # OutlineFilter
 
-PixiJS filter to apply an outline/stroke effect.
+> PixiJS filter to apply an outline/stroke effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=OutlineFilter)
 
 ## Installation
 

--- a/filters/pixelate/README.md
+++ b/filters/pixelate/README.md
@@ -1,6 +1,8 @@
 # PixelateFilter
 
-PixiJS filter to apply a pixelation effect.
+> PixiJS filter to apply a pixelation effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=PixelateFilter)
 
 ## Installation
 

--- a/filters/radial-blur/README.md
+++ b/filters/radial-blur/README.md
@@ -1,6 +1,8 @@
 # RadialBlurFilter
 
-PixiJS filter to apply a radial blur effect.
+> PixiJS filter to apply a radial blur effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=RadialBlurFilter)
 
 ## Installation
 

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -2,7 +2,7 @@
 
 > PixiJS filter to apply reflection and wave effect.
 
-[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AdjustBasicFilter)
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ReflectionFilter)
 
 ## Installation
 

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -1,4 +1,4 @@
-# AdjustBasicFilter
+# ReflectionFilter
 
 > PixiJS filter to apply reflection and wave effect.
 

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -1,6 +1,8 @@
 # AdjustBasicFilter
 
-PixiJS filter to apply reflection and wave effect.
+> PixiJS filter to apply reflection and wave effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=AdjustBasicFilter)
 
 ## Installation
 

--- a/filters/rgb-split/README.md
+++ b/filters/rgb-split/README.md
@@ -1,6 +1,8 @@
 # RGBSplitFilter
 
-PixiJS filter to split and shift red, green or blue channels.
+> PixiJS filter to split and shift red, green or blue channels.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=RGBSplitFilter)
 
 ## Installation
 

--- a/filters/shockwave/README.md
+++ b/filters/shockwave/README.md
@@ -1,6 +1,8 @@
 # ShockwaveFilter
 
-PixiJS filter to apply a shockwave-type effect.
+> PixiJS filter to apply a shockwave-type effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ShockwaveFilter)
 
 ## Installation
 

--- a/filters/simple-lightmap/README.md
+++ b/filters/simple-lightmap/README.md
@@ -1,6 +1,8 @@
 # SimpleLightmapFilter
 
-PixiJS filter to create a light-map from a texture.
+> PixiJS filter to create a light-map from a texture.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=SimpleLightmapFilter)
 
 ## Installation
 

--- a/filters/tilt-shift/README.md
+++ b/filters/tilt-shift/README.md
@@ -1,6 +1,8 @@
 # TiltShiftFilter
 
-PixiJS filter to render a tilt-shift-like camera effect.
+> PixiJS filter to render a tilt-shift-like camera effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=TiltShiftFilter)
 
 ## Installation
 

--- a/filters/twist/README.md
+++ b/filters/twist/README.md
@@ -1,6 +1,8 @@
 # TwistFilter
 
-PixiJS filter to apply a twist effect to a DisplayObject.
+> PixiJS filter to apply a twist effect to a DisplayObject.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=TwistFilter)
 
 ## Installation
 

--- a/filters/zoom-blur/README.md
+++ b/filters/zoom-blur/README.md
@@ -1,6 +1,8 @@
 # ZoomBlurFilter
 
-PixiJS filter to apply zoom blur effect.
+> PixiJS filter to apply zoom blur effect.
+
+[View demo](https://filters.pixijs.download/main/demo/index.html?enabled=ZoomBlurFilter)
 
 ## Installation
 

--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -325,6 +325,7 @@ export default class DemoApplication extends Application
 
         if (filter.enabled)
         {
+            folder.open();
             folder.domElement.className += ' enabled';
         }
 

--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -64,6 +64,8 @@ export default class DemoApplication extends Application
             initHeight + (this.padding * 2),
         );
 
+        this.enabledFilters = [];
+
         const app = this;
 
         this.gui = gui;
@@ -303,7 +305,7 @@ export default class DemoApplication extends Application
         const filter = new ClassRef(...(options.args || []));
 
         // Set enabled status
-        filter.enabled = options.enabled;
+        filter.enabled = (options.enabled && this.enabledFilters.length === 0) || this.enabledFilters.includes(id);
 
         // Track enabled change with analytics
         folder.add(filter, 'enabled').onChange((enabled) =>

--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -265,7 +265,6 @@ export default class DemoApplication extends Application
      * @param {array} [options.args] Constructor arguments
      * @param {boolean} [options.fishOnly=false] Apply to fish only, not whole scene
      * @param {boolean} [options.enabled=false] Filter is enabled by default
-     * @param {boolean} [options.opened=false] Filter Folder is opened by default
      * @param {function} [oncreate] Function takes filter and gui folder as
      *        arguments and is scoped to the Demo application.
      * @return {PIXI.Filter} Instance of new filter
@@ -324,12 +323,7 @@ export default class DemoApplication extends Application
             }
         });
 
-        if (options.opened)
-        {
-            folder.open();
-        }
-
-        if (options.enabled)
+        if (filter.enabled)
         {
             folder.domElement.className += ' enabled';
         }

--- a/tools/demo/src/filters/godray.js
+++ b/tools/demo/src/filters/godray.js
@@ -6,7 +6,6 @@ export default function ()
 
     this.addFilter('GodrayFilter', {
         enabled: false,
-        opened: false,
         oncreate(folder)
         {
             this.alpha = 1;

--- a/tools/demo/src/filters/old-film.js
+++ b/tools/demo/src/filters/old-film.js
@@ -5,7 +5,6 @@ export default function ()
     app.addFilter('OldFilmFilter', {
         enabled: false,
         global: false,
-        opened: false,
         args: [[app.initWidth / 2, app.initHeight / 2]],
         oncreate(folder)
         {

--- a/tools/demo/src/index.js
+++ b/tools/demo/src/index.js
@@ -1,10 +1,13 @@
 import './ga';
 import DemoApplication from './DemoApplication';
 import * as filters from './filters';
+import { getEnabledFiltersFromQueryString } from './utils';
 
 const main = async () =>
 {
     const app = new DemoApplication();
+
+    app.enabledFilters = getEnabledFiltersFromQueryString();
 
     await app.load({
         background: 'images/displacement_BG.jpg',

--- a/tools/demo/src/utils.js
+++ b/tools/demo/src/utils.js
@@ -1,0 +1,11 @@
+export function getEnabledFiltersFromQueryString()
+{
+    const params = new URLSearchParams(window.location.search);
+
+    if (!params.has('enabled'))
+    {
+        return [];
+    }
+
+    return params.get('enabled').split(',');
+}


### PR DESCRIPTION
This would enable linking to the demo application with one or several filters enabled.

```
/tools/demo/index.html?enabled=AsciiFilter
/tools/demo/index.html?enabled=AsciiFilter,BevelFilter
```
[filter_enable.webm](https://user-images.githubusercontent.com/1616817/209258456-fe9b070f-5676-4e35-ac74-3d7ef62bd032.webm)

For example; the preview images in readmes could be linked directly to the demo page.
![image](https://user-images.githubusercontent.com/1616817/209257559-aa64add5-b690-4691-bd96-fb65e4aec530.png)
