### PR TITLE
Fixed flipped characters in AsciiFilter

### DIFF
--- a/filters/ascii/src/ascii.frag
+++ b/filters/ascii/src/ascii.frag
@@ -52,10 +52,10 @@ void main()
     vec2 pixCoord = pixelate(coord, vec2(pixelSize));
     pixCoord = unmapCoord(pixCoord);
 
-    // sample the color at grid the position
+    // sample the color at grid position
     vec4 color = texture2D(uSampler, pixCoord);
 
-    // brightness of the color as it's received by the human eye
+    // brightness of the color as it's perceived by the human eye
     float gray = 0.3 * color.r + 0.59 * color.g + 0.11 * color.b;
 
     // determine the character to use

--- a/filters/ascii/src/ascii.frag
+++ b/filters/ascii/src/ascii.frag
@@ -22,17 +22,17 @@ vec2 unmapCoord( vec2 coord )
 
 vec2 pixelate(vec2 coord, vec2 size)
 {
-    return floor( coord / size ) * size;
+    return floor(coord / size) * size;
 }
 
 vec2 getMod(vec2 coord, vec2 size)
 {
-    return mod( coord , size) / size;
+    return mod(coord, size) / size;
 }
 
 float character(float n, vec2 p)
 {
-    p = floor(p*vec2(4.0, -4.0) + 2.5);
+    p = floor(p*vec2(4.0, 4.0) + 2.5);
 
     if (clamp(p.x, 0.0, 4.0) == p.x)
     {

--- a/filters/ascii/src/ascii.frag
+++ b/filters/ascii/src/ascii.frag
@@ -48,15 +48,17 @@ void main()
 {
     vec2 coord = mapCoord(vTextureCoord);
 
-    // get the rounded color..
+    // get the grid position
     vec2 pixCoord = pixelate(coord, vec2(pixelSize));
     pixCoord = unmapCoord(pixCoord);
 
+    // sample the color at grid the position
     vec4 color = texture2D(uSampler, pixCoord);
 
-    // determine the character to use
-    float gray = (color.r + color.g + color.b) / 3.0;
+    // brightness of the color as it's received by the human eye
+    float gray = 0.3 * color.r + 0.59 * color.g + 0.11 * color.b;
 
+    // determine the character to use
     float n =  65536.0;             // .
     if (gray > 0.2) n = 65600.0;    // :
     if (gray > 0.3) n = 332772.0;   // *


### PR DESCRIPTION
Since the original shader was made for shadertoy where the canvas origin is bottom-left, the characters were upside-down.

This was fixed by simply removing the minus in the character sampling function (line 35).

I've also adjusted the brightness calculation of the sampled pixel color to reflect the variing intensities of color components as they are perceived by the human eye. This change alters the appearance of the result a little but should give better mappings of characters to their source pixels.

fixes #325