### PR TITLE
Output a browser bundle for pixi-filters

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -12,6 +12,7 @@
   "main": "./dist/cjs/pixi-filters.js",
   "module": "./dist/esm/pixi-filters.mjs",
   "bundle": "./dist/browser/pixi-filters.js",
+  "bundleModule": "./dist/browser/pixi-filters.mjs",
   "exports": {
     ".": {
       "import": "./dist/esm/pixi-filters.mjs",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ async function main() {
         ].join('\n');
 
         // Get settings from package JSON
-        let { main, module, bundle, globals } = pkg.config;
+        let { main, module, bundle, bundleModule, globals } = pkg.config;
         const basePath = path.relative(__dirname, pkg.dir);
         const input = path.join(basePath, 'src/index.ts');
         const freeze = false;
@@ -82,16 +82,26 @@ async function main() {
             builds.push({
                 input,
                 external: Object.keys(globals),
-                output: {
-                    name,
-                    banner,
-                    globals,
-                    file: path.join(basePath, bundle),
-                    format: 'iife',
-                    footer,
-                    freeze,
-                    sourcemap,
-                },
+                output: [
+                    {
+                        name,
+                        banner,
+                        globals,
+                        file: path.join(basePath, bundle),
+                        format: 'iife',
+                        footer,
+                        freeze,
+                        sourcemap,
+                    },
+                    {
+                        banner,
+                        globals,
+                        file: path.join(basePath, bundleModule),
+                        format: 'esm',
+                        freeze,
+                        sourcemap,
+                    },
+                ],
                 treeshake: false,
                 plugins,
             });


### PR DESCRIPTION
Closes #326

Adds a new .mjs output file for the `pixi-filters` package to support [importmap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) ([browser support](https://caniuse.com/import-maps)).

For example:

```html
<body>
     <script type="importmap">
    {
        "imports": {
          "pixi.js": "https://cdn.jsdelivr.net/npm/pixi.js@7.x/dist/pixi.min.mjs",
          "@pixi": "https://cdn.jsdelivr.net/npm/pixi.js@7.x/dist/pixi.min.mjs",
          "pixi-filters": "https://filters.pixijs.download/feature/browser-module/pixi-filters.mjs"
      }
    }
    </script>
    <script type="module">
        import {Application, Sprite, Texture} from "pixi.js";
        import {GlowFilter} from "pixi-filters";

        const app = new Application();
        document.body.appendChild(app.view);
        const sprite = app.stage.addChild(new Sprite(Texture.WHITE));
        sprite.filters = [new GlowFilter()];
    </script>
</body>
```

https://jsfiddle.net/bigtimebuddy/t3a15ump/

### Blockers

~~Currently this doesn't work because of the `filters` namespace in the `pixi.js` package. This needs to get fixed before this will work.~~ FIxed