### PR TITLE
Fix actions deprecations, auto-deploy bundle files

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -40,7 +40,7 @@ jobs:
       run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
 
     - name: Build for Distribution
-      uses: xvfb-run --auto-servernum npm run dist
+      run: xvfb-run --auto-servernum npm run dist
 
     # Append assets to releases
     - name: Upload Assets to Release

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Install Canvas Dependencies
+      run: sudo apt-get install xvfb
     - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
@@ -35,12 +37,18 @@ jobs:
     - name: Extract Branch Name
       id: branch_name
       if: github.event_name == 'push'
-      run: echo ::set-output name=BRANCH_NAME::${GITHUB_REF/refs\/heads\//}
+      run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
 
     - name: Build for Distribution
-      uses: GabrielBB/xvfb-action@v1
+      uses: xvfb-run --auto-servernum npm run dist
+
+    # Append assets to releases
+    - name: Upload Assets to Release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
       with:
-        run: npm run dist
+        files: |
+          ./bundle/dist/browser/*
 
     # Examples:
     # 1) PR feature/acme merged into dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
       }
     },
     "filters/color-gradient": {
+      "name": "@pixi/filter-color-gradient",
       "version": "5.1.1",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
### Chores

* Minor update to lock file
* Remove deprecation warnings from GitHub Actions

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: GabrielBB/xvfb-action@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

* Automatically copy browser bundle files to new release