### PR TITLE
Use x/y offset for the DropShadowFilter instead of rotation/distance

### DIFF
--- a/tools/demo/src/filters/drop-shadow.js
+++ b/tools/demo/src/filters/drop-shadow.js
@@ -7,8 +7,8 @@ export default function ()
             folder.add(this, 'blur', 0, 20);
             folder.add(this, 'quality', 0, 20);
             folder.add(this, 'alpha', 0, 1);
-            folder.add(this, 'distance', 0, 50);
-            folder.add(this, 'rotation', 0, 360);
+            folder.add(this.offset, 'x', -50, 50).name('offset.x');
+            folder.add(this.offset, 'y', -50, 50).name('offset.y');
             folder.addColor(this, 'color');
             folder.add(this, 'shadowOnly');
         },

--- a/tools/screenshots/config.json
+++ b/tools/screenshots/config.json
@@ -315,7 +315,10 @@
             "name": "DropShadowFilter",
             "filename": "drop-shadow",
             "options": {
-                "distance": 3
+                "offset": {
+                    "x": 2,
+                    "y": 2
+                }
             },
             "fishOnly": true
         },


### PR DESCRIPTION
Closes #256

### Changed

* Deprecated `rotation` and `distance` from DropShadowFilter in favor of `offset.x` and `offset.y`

```js
import { DropShadowFilter } from '@pixi/filters-drop-shadow';

// Set with constructor options
const filter = new DropShadowFilter({
  offset: { x: 2, y: 2 }, // can also be Point
});

// Set with the offset member
filter.offset.set(4, 4);
```