### PR TITLE
HslAdjustmentFilter: Update calculations of saturation and lightness

### DIFF
--- a/filters/hsl-adjustment/src/hsladjustment.frag
+++ b/filters/hsl-adjustment/src/hsladjustment.frag
@@ -12,7 +12,7 @@ uniform float uLightness;
 const vec3 weight = vec3(0.299, 0.587, 0.114);
 
 float getBrightness(vec4 color) {
-    return (color.r * weight.r + color.g * weight.g  + color.b * weight.b) * color.a;
+    return (color.r * weight.r + color.g * weight.g + color.b * weight.b) * color.a;
 }
 
 // https://gist.github.com/mairod/a75e7b44f68110e1576d77419d608786?permalink_comment_id=3195243#gistcomment-3195243
@@ -34,7 +34,7 @@ void main()
     float brightness = getBrightness(result);
 
     // colorize
-    if (uColorize)  {
+    if (uColorize) {
         result.rgb = vec3(brightness, 0, 0);
     }
 
@@ -42,11 +42,17 @@ void main()
     result.rgb = hueShift(result.rgb, uHue);
 
     // saturation
-    result.rgb = mix(vec3(brightness), result.rgb, 1.+uSaturation);
-    result.rgb = clamp(result.rgb, 0., 1.);
+    // https://github.com/evanw/glfx.js/blob/master/src/filters/adjust/huesaturation.js
+    float average = (color.r + color.g + color.b) / 3.0;
+
+    if (uSaturation > 0.) {
+        result.rgb += (average - result.rgb) * (1. - 1. / (1.001 - uSaturation));
+    } else {
+        result.rgb -= (average - result.rgb) * uSaturation;
+    }
 
     // lightness
-    result.rgb += vec3(uLightness) * color.a;
+    result.rgb = mix(result.rgb, vec3(ceil(uLightness)) * color.a, abs(uLightness));
 
     // alpha
     gl_FragColor = mix(color, result, uAlpha);

--- a/filters/hsl-adjustment/src/hsladjustment.frag
+++ b/filters/hsl-adjustment/src/hsladjustment.frag
@@ -35,18 +35,18 @@ void main()
 
     // colorize
     if (uColorize)  {
-        result.xyz = vec3(brightness, 0, 0);
+        result.rgb = vec3(brightness, 0, 0);
     }
 
     // hue
-    result.xyz = hueShift(result.xyz, uHue);
+    result.rgb = hueShift(result.rgb, uHue);
 
     // saturation
-    result.xyz = mix(vec3(brightness), result.xyz, 1.+uSaturation);
-    result.xyz = clamp(result.xyz, 0., 1.);
+    result.rgb = mix(vec3(brightness), result.rgb, 1.+uSaturation);
+    result.rgb = clamp(result.rgb, 0., 1.);
 
     // lightness
-    result.xyz += vec3(uLightness) * color.a;
+    result.rgb += vec3(uLightness) * color.a;
 
     // alpha
     gl_FragColor = mix(color, result, uAlpha);

--- a/filters/hsl-adjustment/src/hsladjustment.frag
+++ b/filters/hsl-adjustment/src/hsladjustment.frag
@@ -11,8 +11,8 @@ uniform float uLightness;
 // https://en.wikipedia.org/wiki/Luma_(video)
 const vec3 weight = vec3(0.299, 0.587, 0.114);
 
-float getBrightness(vec4 color) {
-    return (color.r * weight.r + color.g * weight.g + color.b * weight.b) * color.a;
+float getWeightedAverage(vec3 rgb) {
+    return rgb.r * weight.r + rgb.g * weight.g + rgb.b * weight.b;
 }
 
 // https://gist.github.com/mairod/a75e7b44f68110e1576d77419d608786?permalink_comment_id=3195243#gistcomment-3195243
@@ -31,11 +31,10 @@ void main()
 {
     vec4 color = texture2D(uSampler, vTextureCoord);
     vec4 result = color;
-    float brightness = getBrightness(result);
 
     // colorize
     if (uColorize) {
-        result.rgb = vec3(brightness, 0, 0);
+        result.rgb = vec3(getWeightedAverage(result.rgb), 0., 0.);
     }
 
     // hue
@@ -43,7 +42,7 @@ void main()
 
     // saturation
     // https://github.com/evanw/glfx.js/blob/master/src/filters/adjust/huesaturation.js
-    float average = (color.r + color.g + color.b) / 3.0;
+    float average = (result.r + result.g + result.b) / 3.0;
 
     if (uSaturation > 0.) {
         result.rgb += (average - result.rgb) * (1. - 1. / (1.001 - uSaturation));


### PR DESCRIPTION
**Saturation**: Use linear calcuation for negative values (desaturate) and non-linear `(1.-1./(1.001-x))` for positive values (saturate). This allows extreme color values and works better with the `colorize` option.

Comparison - new (left) vs current (right):

![comp1](https://user-images.githubusercontent.com/1616817/216655574-baa78be1-7f8e-4734-8bc8-29abab996033.png)
![comp2](https://user-images.githubusercontent.com/1616817/216655589-2bb0cedb-a605-4294-ade9-92cc97190527.png)


**Lightness**: Mix black/white instead of add (same as photoshop/photopea).

![comp3](https://user-images.githubusercontent.com/1616817/216657395-0a1dab7f-c87b-4c4e-9532-3a1f00f77b9e.png)
