### PR TITLE
Feature: Allow color-gradient to replace original colors

### DIFF
--- a/filters/color-gradient/src/ColorGradientFilter.ts
+++ b/filters/color-gradient/src/ColorGradientFilter.ts
@@ -18,7 +18,7 @@ export type DefaultOptions = {
     angle?: number;
     alpha?: number;
     maxColors?: number;
-    replaceColors?: boolean;
+    replace?: boolean;
 };
 
 export type CssOptions = {
@@ -60,7 +60,7 @@ class ColorGradientFilter extends Filter
         alpha: 1.0,
         angle: 90.0,
         maxColors: 0,
-        replaceColors: false,
+        replace: false,
     };
 
     private _stops: ColorStop[] = [];
@@ -190,14 +190,14 @@ class ColorGradientFilter extends Filter
      * will be multiplied with it
      * @default false
      */
-    set replaceColors(value: boolean)
+    set replace(value: boolean)
     {
-        this.uniforms.uReplaceColors = value;
+        this.uniforms.uReplace = value;
     }
 
-    get replaceColors(): boolean
+    get replace(): boolean
     {
-        return this.uniforms.uReplaceColors;
+        return this.uniforms.uReplace;
     }
 }
 

--- a/filters/color-gradient/src/ColorGradientFilter.ts
+++ b/filters/color-gradient/src/ColorGradientFilter.ts
@@ -18,6 +18,7 @@ export type DefaultOptions = {
     angle?: number;
     alpha?: number;
     maxColors?: number;
+    replaceColors?: boolean;
 };
 
 export type CssOptions = {
@@ -59,6 +60,7 @@ class ColorGradientFilter extends Filter
         alpha: 1.0,
         angle: 90.0,
         maxColors: 0,
+        replaceColors: false,
     };
 
     private _stops: ColorStop[] = [];
@@ -181,6 +183,21 @@ class ColorGradientFilter extends Filter
     get maxColors(): number
     {
         return this.uniforms.uMaxColors;
+    }
+
+    /**
+     * If true, the gradient will replace the existing color, otherwise it
+     * will be multiplied with it
+     * @default false
+     */
+    set replaceColors(value: boolean)
+    {
+        this.uniforms.uReplaceColors = value;
+    }
+
+    get replaceColors(): boolean
+    {
+        return this.uniforms.uReplaceColors;
     }
 }
 

--- a/filters/color-gradient/src/colorGradient.frag
+++ b/filters/color-gradient/src/colorGradient.frag
@@ -18,7 +18,7 @@ uniform int uType;
 uniform float uAngle;
 uniform float uAlpha;
 uniform int uMaxColors;
-uniform bool uReplaceColors;
+uniform bool uReplace;
 
 struct ColorStop {
     float offset;
@@ -123,7 +123,7 @@ void main(void) {
     float gradientAlpha = uAlpha * currentColor.a;
     vec4 gradientColor = mix(colorFrom, colorTo, relativePercent) * gradientAlpha;
 
-    if (uReplaceColors == false) {
+    if (uReplace == false) {
         // mix resulting color with current color
         gl_FragColor = gradientColor + currentColor*(1.-gradientColor.a);
     } else {

--- a/filters/color-gradient/src/colorGradient.frag
+++ b/filters/color-gradient/src/colorGradient.frag
@@ -18,6 +18,7 @@ uniform int uType;
 uniform float uAngle;
 uniform float uAlpha;
 uniform int uMaxColors;
+uniform bool uReplaceColors;
 
 struct ColorStop {
     float offset;
@@ -122,6 +123,11 @@ void main(void) {
     float gradientAlpha = uAlpha * currentColor.a;
     vec4 gradientColor = mix(colorFrom, colorTo, relativePercent) * gradientAlpha;
 
-    // mix resulting color with current color
-    gl_FragColor = gradientColor + currentColor*(1.-gradientColor.a);
+    if (uReplaceColors == false) {
+        // mix resulting color with current color
+        gl_FragColor = gradientColor + currentColor*(1.-gradientColor.a);
+    } else {
+        // replace with gradient color
+        gl_FragColor = gradientColor;
+    }
 }

--- a/tools/demo/src/filters/color-gradient.js
+++ b/tools/demo/src/filters/color-gradient.js
@@ -156,6 +156,7 @@ export default function ()
             folder.add(this, 'alpha', 0, 1);
             folder.add(this, 'angle', 0, 360, 1);
             folder.add(this, 'maxColors', 0, 24, 1);
+            folder.add(this, 'replace', false);
             applyDefaultOptions(stops);
         },
     });


### PR DESCRIPTION
This PR allows color-gradient to replace the original colors.

Preserves backwards compatibility.

This is useful for e.g. drawing a gradient that fades to transparent - in this case the original color of the pixels should be discarded.