### PR TITLE
Chore: ASCII Filter Deprecations

### DIFF
--- a/src/ascii/AsciiFilter.ts
+++ b/src/ascii/AsciiFilter.ts
@@ -1,4 +1,5 @@
-import { Color, ColorSource, Filter, GlProgram, GpuProgram } from 'pixi.js';
+// eslint-disable-next-line camelcase
+import { Color, ColorSource, deprecation, Filter, GlProgram, GpuProgram, v8_0_0 } from 'pixi.js';
 import { vertex, wgslVertex } from '../defaults';
 import fragment from './ascii.frag';
 import source from './ascii.wgsl';
@@ -53,13 +54,30 @@ export class AsciiFilter extends Filter
 
     private _color!: Color;
 
-    constructor(options?: AsciiFilterOptions)
+    constructor(options?: AsciiFilterOptions);
+    /**
+     * @deprecated since 8.0.0
+     *
+     * @param {number} [size=8] - Size of the font
+     */
+    constructor(size: number);
+    constructor(...args: [AsciiFilterOptions?] | [number])
     {
+        let options = args[0] ?? {};
+
+        if (typeof options === 'number')
+        {
+            // eslint-disable-next-line max-len
+            deprecation(v8_0_0, 'AsciiFilter constructor params are now options object. See params: { size, color, replaceColor }');
+
+            options = { size: options };
+        }
+
         const replaceColor = options?.color && options.replaceColor !== false;
 
         options = { ...AsciiFilter.DEFAULT_OPTIONS, ...options } as AsciiFilterOptions;
 
-        const gpuProgram = new GpuProgram({
+        const gpuProgram = GpuProgram.from({
             vertex: {
                 source: wgslVertex,
                 entryPoint: 'mainVertex',
@@ -70,7 +88,7 @@ export class AsciiFilter extends Filter
             },
         });
 
-        const glProgram = new GlProgram({
+        const glProgram = GlProgram.from({
             vertex,
             fragment,
             name: 'ascii-filter',

--- a/src/ascii/AsciiFilter.ts
+++ b/src/ascii/AsciiFilter.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line camelcase
-import { Color, ColorSource, deprecation, Filter, GlProgram, GpuProgram, v8_0_0 } from 'pixi.js';
+import { Color, ColorSource, deprecation, Filter, GlProgram, GpuProgram } from 'pixi.js';
 import { vertex, wgslVertex } from '../defaults';
 import fragment from './ascii.frag';
 import source from './ascii.wgsl';
@@ -56,7 +55,7 @@ export class AsciiFilter extends Filter
 
     constructor(options?: AsciiFilterOptions);
     /**
-     * @deprecated since 8.0.0
+     * @deprecated since 6.0.0
      *
      * @param {number} [size=8] - Size of the font
      */
@@ -68,7 +67,7 @@ export class AsciiFilter extends Filter
         if (typeof options === 'number')
         {
             // eslint-disable-next-line max-len
-            deprecation(v8_0_0, 'AsciiFilter constructor params are now options object. See params: { size, color, replaceColor }');
+            deprecation('6.0.0', 'AsciiFilter constructor params are now options object. See params: { size, color, replaceColor }');
 
             options = { size: options };
         }


### PR DESCRIPTION
- Add deprecations for the ASCII filter.
- Use `GpuProgram.from` and `GlProgram.from` for caching.