### PR TITLE
Chore: Outline Filter Deprecations

### DIFF
--- a/src/outline/OutlineFilter.ts
+++ b/src/outline/OutlineFilter.ts
@@ -1,4 +1,5 @@
-import { Color, Filter, GlProgram, GpuProgram } from 'pixi.js';
+// eslint-disable-next-line camelcase
+import { Color, deprecation, Filter, GlProgram, GpuProgram, v8_0_0 } from 'pixi.js';
 import { vertex, wgslVertex } from '../defaults';
 import fragment from './outline.frag';
 import source from './outline.wgsl';
@@ -77,13 +78,40 @@ export class OutlineFilter extends Filter
     private _quality!: number;
     private _color!: Color;
 
-    constructor(options?: OutlineFilterOptions)
+    constructor(options?: OutlineFilterOptions);
+    /**
+     * @deprecated since 8.0.0
+     *
+     * @param {number} [thickness=1] - The tickness of the outline. Make it 2 times more for resolution 2
+     * @param {number} [color=0x000000] - The color of the outline.
+     * @param {number} [quality=0.1] - The quality of the outline from `0` to `1`, using a higher quality
+     *        setting will result in slower performance and more accuracy.
+     * @param {number} [alpha=1.0] - The alpha of the outline.
+     * @param {boolean} [knockout=false] - Only render outline, not the contents.
+     */
+    constructor(thickness?: number, color?: number, quality?: number, alpha?: number, knockout?: boolean);
+    constructor(...args: [OutlineFilterOptions?] | [number?, number?, number?, number?, boolean?])
     {
+        let options = args[0] ?? {};
+
+        if (typeof options === 'number')
+        {
+            // eslint-disable-next-line max-len
+            deprecation(v8_0_0, 'OutlineFilter constructor params are now options object. See params: { thickness, color, quality, alpha, knockout }');
+
+            options = { thickness: options };
+
+            if (args[1]) options.color = args[1];
+            if (args[2]) options.quality = args[2];
+            if (args[3]) options.alpha = args[3];
+            if (args[4]) options.knockout = args[4];
+        }
+
         options = { ...OutlineFilter.DEFAULT_OPTIONS, ...options };
 
         const quality = options.quality ?? 0.1;
 
-        const gpuProgram = new GpuProgram({
+        const gpuProgram = GpuProgram.from({
             vertex: {
                 source: wgslVertex,
                 entryPoint: 'mainVertex',
@@ -94,7 +122,7 @@ export class OutlineFilter extends Filter
             },
         });
 
-        const glProgram = new GlProgram({
+        const glProgram = GlProgram.from({
             vertex,
             fragment: fragment.replace(/\$\{ANGLE_STEP\}/, OutlineFilter.getAngleStep(quality).toFixed(7)),
             name: 'outline-filter',

--- a/src/outline/OutlineFilter.ts
+++ b/src/outline/OutlineFilter.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line camelcase
-import { Color, deprecation, Filter, GlProgram, GpuProgram, v8_0_0 } from 'pixi.js';
+import { Color, deprecation, Filter, GlProgram, GpuProgram } from 'pixi.js';
 import { vertex, wgslVertex } from '../defaults';
 import fragment from './outline.frag';
 import source from './outline.wgsl';
@@ -80,7 +79,7 @@ export class OutlineFilter extends Filter
 
     constructor(options?: OutlineFilterOptions);
     /**
-     * @deprecated since 8.0.0
+     * @deprecated since 6.0.0
      *
      * @param {number} [thickness=1] - The tickness of the outline. Make it 2 times more for resolution 2
      * @param {number} [color=0x000000] - The color of the outline.
@@ -97,14 +96,14 @@ export class OutlineFilter extends Filter
         if (typeof options === 'number')
         {
             // eslint-disable-next-line max-len
-            deprecation(v8_0_0, 'OutlineFilter constructor params are now options object. See params: { thickness, color, quality, alpha, knockout }');
+            deprecation('6.0.0', 'OutlineFilter constructor params are now options object. See params: { thickness, color, quality, alpha, knockout }');
 
             options = { thickness: options };
 
-            if (args[1]) options.color = args[1];
-            if (args[2]) options.quality = args[2];
-            if (args[3]) options.alpha = args[3];
-            if (args[4]) options.knockout = args[4];
+            if (args[1] !== undefined) options.color = args[1];
+            if (args[2] !== undefined) options.quality = args[2];
+            if (args[3] !== undefined) options.alpha = args[3];
+            if (args[4] !== undefined) options.knockout = args[4];
         }
 
         options = { ...OutlineFilter.DEFAULT_OPTIONS, ...options };


### PR DESCRIPTION
- Add deprecations for the Outline filter.
- Use GpuProgram.from and GlProgram.from for caching.