### PR TITLE
Chore: Simple Lightmap Filter Deprecations

### DIFF
--- a/src/simple-lightmap/SimpleLightmapFilter.ts
+++ b/src/simple-lightmap/SimpleLightmapFilter.ts
@@ -8,8 +8,6 @@ import {
     GpuProgram,
     RenderSurface,
     Texture,
-    // eslint-disable-next-line camelcase
-    v8_0_0,
 } from 'pixi.js';
 import { vertex, wgslVertex } from '../defaults';
 import fragment from './simple-lightmap.frag';
@@ -71,7 +69,7 @@ export class SimpleLightmapFilter extends Filter
 
     constructor(options: SimpleLightmapFilterOptions);
     /**
-     * @deprecated since 8.0.0
+     * @deprecated since 6.0.0
      *
      * @param {PIXI.Texture} texture - a texture where your lightmap is rendered
      * @param {Array<number>|number} [color=0x000000] - An RGBA array of the ambient color
@@ -85,12 +83,12 @@ export class SimpleLightmapFilter extends Filter
         if (options instanceof Texture)
         {
             // eslint-disable-next-line max-len
-            deprecation(v8_0_0, 'SimpleLightmapFilter constructor params are now options object. See params: { lightMap, color, alpha }');
+            deprecation('6.0.0', 'SimpleLightmapFilter constructor params are now options object. See params: { lightMap, color, alpha }');
 
             options = { lightMap: options };
 
-            if (args[1]) options.color = args[1];
-            if (args[2]) options.alpha = args[2];
+            if (args[1] !== undefined) options.color = args[1];
+            if (args[2] !== undefined) options.alpha = args[2];
         }
 
         options = { ...SimpleLightmapFilter.DEFAULT_OPTIONS, ...options };

--- a/src/simple-lightmap/SimpleLightmapFilter.ts
+++ b/src/simple-lightmap/SimpleLightmapFilter.ts
@@ -1,7 +1,21 @@
-import { Color, ColorSource, Filter, FilterSystem, GlProgram, GpuProgram, RenderSurface, Texture } from 'pixi.js';
+import {
+    Color,
+    ColorSource,
+    deprecation,
+    Filter,
+    FilterSystem,
+    GlProgram,
+    GpuProgram,
+    RenderSurface,
+    Texture,
+    // eslint-disable-next-line camelcase
+    v8_0_0,
+} from 'pixi.js';
 import { vertex, wgslVertex } from '../defaults';
 import fragment from './simple-lightmap.frag';
 import source from './simple-lightmap.wgsl';
+
+type DeprecatedColor = number | number[];
 
 export interface SimpleLightmapFilterOptions
 {
@@ -55,13 +69,35 @@ export class SimpleLightmapFilter extends Filter
     private _color!: Color;
     private _lightMap!: Texture;
 
-    constructor(options: SimpleLightmapFilterOptions)
+    constructor(options: SimpleLightmapFilterOptions);
+    /**
+     * @deprecated since 8.0.0
+     *
+     * @param {PIXI.Texture} texture - a texture where your lightmap is rendered
+     * @param {Array<number>|number} [color=0x000000] - An RGBA array of the ambient color
+     * @param {number} [alpha=1] - Default alpha set independent of color (if it's a number, not array).
+     */
+    constructor(texture: Texture, color?: DeprecatedColor, alpha?: number);
+    constructor(...args: [SimpleLightmapFilterOptions] | [Texture, DeprecatedColor?, number?])
     {
+        let options = args[0] ?? {};
+
+        if (options instanceof Texture)
+        {
+            // eslint-disable-next-line max-len
+            deprecation(v8_0_0, 'SimpleLightmapFilter constructor params are now options object. See params: { lightMap, color, alpha }');
+
+            options = { lightMap: options };
+
+            if (args[1]) options.color = args[1];
+            if (args[2]) options.alpha = args[2];
+        }
+
         options = { ...SimpleLightmapFilter.DEFAULT_OPTIONS, ...options };
 
         if (!options.lightMap) throw Error('No light map texture source was provided to SimpleLightmapFilter');
 
-        const gpuProgram = new GpuProgram({
+        const gpuProgram = GpuProgram.from({
             vertex: {
                 source: wgslVertex,
                 entryPoint: 'mainVertex',
@@ -71,7 +107,7 @@ export class SimpleLightmapFilter extends Filter
                 entryPoint: 'mainFragment',
             },
         });
-        const glProgram = new GlProgram({
+        const glProgram = GlProgram.from({
             vertex,
             fragment,
             name: 'simple-lightmap-filter',


### PR DESCRIPTION
- Add deprecations for the Simple Lightmap filter.
- Use GpuProgram.from and GlProgram.from for caching.