### PR TITLE
Chore: Bump extension-scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2493,9 +2493,9 @@
       }
     },
     "node_modules/@pixi/extension-scripts": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@pixi/extension-scripts/-/extension-scripts-2.4.0.tgz",
-      "integrity": "sha512-wh+o3mlfgOqRnFzB0a1fokv+eE7/7A9yq40citK6x1Znesh6qsS0/kLnx2fzKeie1+VnhySxQL6xzKWpC4arOg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@pixi/extension-scripts/-/extension-scripts-2.4.1.tgz",
+      "integrity": "sha512-99kPhE3xk4269k3qADtinRf/0FydVcDOBofhffpM8tqwTwqyyJ7NNqbdvIEiKiPFtQhESv+0tWoKVb7/SRmPdg==",
       "dev": true,
       "dependencies": {
         "@kayahr/jest-electron-runner": "^29.3.0",


### PR DESCRIPTION
Bumping extension-scripts solves two issues:
* Publishing not working correctly (`NODE_AUTH_TOKEN `not getting passed along to `npm publish`)
* Processes with a non-zero result not passing along the result