### PR TITLE
fix: tree shaking when using default import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pixi-filters",
   "version": "6.0.5",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./lib/index.mjs",


### PR DESCRIPTION
This PR adds `sideEffect: false` to the package json to allow for bundlers to correctly tree shake the library when using the default export e.g.

`import { XYZ } from 'pixi-filters';`

Before: 
![image](https://github.com/user-attachments/assets/a6708ad0-5a6d-44e0-a3e4-ae590051c63b)

After:
![image](https://github.com/user-attachments/assets/da992329-6092-4842-9e49-e11a2626de4a)
