### PR TITLE
chore: Use the latest v8 in example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -7,7 +7,7 @@
         <meta name='viewport' content='width=device-width, initial-scale=1.0'>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" />
         <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.12.0"></script>
-        <script src="https://pixijs.download/next-v8/pixi.min.js"></script>
+        <script src="https://pixijs.download/dev/pixi.min.js"></script>
         <script src="../dist/pixi-filters.js"></script>
         <link rel="stylesheet" href="./index.css" />
     </head>


### PR DESCRIPTION
We should be using the latest v8 in dev, not `next-v8` which is no longer maintained